### PR TITLE
Update vcf_parse to v0.1.2

### DIFF
--- a/1_SomaticAmplicon.sh
+++ b/1_SomaticAmplicon.sh
@@ -481,11 +481,12 @@ if [ -d /data/diagnostics/pipelines/SomaticAmplicon/SomaticAmplicon-"$version"/"
 
 	source /home/transfer/miniconda3/bin/activate vcf_parse
 	
-	python /data/diagnostics/apps/vcf_parse/vcf_parse-0.1.0/vcf_parse.py \
+	python /data/diagnostics/apps/vcf_parse/vcf_parse-0.1.2/vcf_parse.py \
 	--transcripts /data/diagnostics/pipelines/SomaticAmplicon/SomaticAmplicon-"$version"/"$panel"/"$panel"_PreferredTranscripts.txt \
 	--transcript_strictness low \
 	--known_variants /data/diagnostics/pipelines/SomaticAmplicon/SomaticAmplicon-"$version"/"$panel"/"$panel"_KnownVariants.vcf \
 	--config /data/diagnostics/pipelines/SomaticAmplicon/SomaticAmplicon-"$version"/"$panel"/"$panel"_ReportConfig.txt \
+        --filter_non_pass \
 	hotspot_variants/"$seqId"_"$sampleId"_"$target"_filtered_meta_annotated.vcf
 	
 	source /home/transfer/miniconda3/bin/deactivate
@@ -500,11 +501,12 @@ fi
 
 source /home/transfer/miniconda3/bin/activate vcf_parse
 
-python /data/diagnostics/apps/vcf_parse/vcf_parse-0.1.0/vcf_parse.py \
+python /data/diagnostics/apps/vcf_parse/vcf_parse-0.1.2/vcf_parse.py \
 --transcripts /data/diagnostics/pipelines/SomaticAmplicon/SomaticAmplicon-"$version"/"$panel"/"$panel"_PreferredTranscripts.txt \
 --transcript_strictness low \
 --known_variants /data/diagnostics/pipelines/SomaticAmplicon/SomaticAmplicon-"$version"/"$panel"/"$panel"_KnownVariants.vcf \
 --config /data/diagnostics/pipelines/SomaticAmplicon/SomaticAmplicon-"$version"/"$panel"/"$panel"_ReportConfig.txt \
+--filter_non_pass \
 "$seqId"_"$sampleId"_filtered_meta_annotated.vcf
 
 mv "$sampleId"_VariantReport.txt "$seqId"_"$sampleId"_VariantReport.txt


### PR DESCRIPTION
Update vcf_parse to include fix when VCF is empty 
Add --filter_non_pass flag to retain filtering behaviour of v0.1.0
Fixes #7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/awgl/somaticamplicon/8)
<!-- Reviewable:end -->
