### PR TITLE
Wren fix

### DIFF
--- a/1_SomaticAmplicon.sh
+++ b/1_SomaticAmplicon.sh
@@ -623,7 +623,8 @@ if [ $complete -eq $expected ]; then
     # virtual hood
     if [ $generate_worksheets == true ]; then
     
-
+        # Remove this line once checked to see if run
+        echo -e "This is to see if the generate worksheets is actually being entered" > /data/output/results/"$seqId"/"$panel"/"$seqId"_test.txt
         # identify name of NTC
         ntc=$(for s in /data/output/results/"$seqId"/"$panel"/*/; do echo $(basename $s);done | grep 'NTC')
 
@@ -646,7 +647,7 @@ if [ $complete -eq $expected ]; then
             if [ $sample != $ntc ]; then
 
                 if [ $referral == 'Melanoma' ] || [ $referral == 'Lung' ] || [ $referral == 'Colorectal' ] || [ $referral == 'Glioma' ] || [ $referral == 'Tumour' ] || [ $referral == 'GIST' ]; then
-                    $VHOOD /opt/conda/bin/VirtualHood-1.2.0/CRM_report_new_referrals.py --runid $seqId --sampleid $sample --worksheet $worklistId --referral $referral --NTC_name $ntc --path /data/output/results/$seqId/$panel/ --artefacts /data/temp/artefacts_lists/
+                    $VHOOD /opt/conda/bin/VirtualHood-1.2.0/CRM_report_new_referrals.py --runid $seqId --sampleid $sample --worksheet $worklistId --referral $referral --NTC_name $ntc --path /data/output/results/"$seqId"/"$panel"/ --artefacts /data/temp/artefacts_lists/
                 fi
             fi
         done

--- a/1_SomaticAmplicon.sh
+++ b/1_SomaticAmplicon.sh
@@ -625,10 +625,10 @@ if [ $complete -eq $expected ]; then
     
 
         # identify name of NTC
-        ntc=$(for s in /data/output/results/$seqId/$panel/*/; do echo $(basename $s);done | grep 'NTC')
+        ntc=$(for s in /data/output/results/"$seqId"/"$panel"/*/; do echo $(basename $s);done | grep 'NTC')
 
         # loop over all samples and generate a report
-        for sample_path in /data/output/results/$seqId/$panel/*/; do
+        for sample_path in /data/output/results/"$seqId"/"$panel"/*/; do
             
             # clear previous instance
             unset referral 
@@ -636,7 +636,7 @@ if [ $complete -eq $expected ]; then
             # set variables
             sample=$(basename $sample_path)
             # Change this path so not hardcoded 
-            . /data/output/results/$seqId/$panel/$sample/*.variables
+            . /data/output/results/"$seqId"/"$panel"/"$sample"/*.variables
             echo "Generating worksheet for $sample"
 
             # check that referral variable is defined, if not set as NA

--- a/1_SomaticAmplicon.sh
+++ b/1_SomaticAmplicon.sh
@@ -524,8 +524,7 @@ fi
 if [ $custom_variants == true ]; then
     mkdir hotspot_variants
 
-    # Making marker file for 101X and Myeloid
-    # touch move_complete.txt
+
 
     for bedFile in $(ls /data/diagnostics/pipelines/SomaticAmplicon/SomaticAmplicon-"$version"/"$panel"/hotspot_variants/*.bed); do
 
@@ -556,9 +555,7 @@ if [ $custom_variants == true ]; then
 
     done
 
-# Making a marker file for 102X
-# else
-    # touch move_complete.txt
+
 
 fi
 

--- a/1_SomaticAmplicon.sh
+++ b/1_SomaticAmplicon.sh
@@ -623,8 +623,6 @@ if [ $complete -eq $expected ]; then
     # virtual hood
     if [ $generate_worksheets == true ]; then
     
-        # Remove this line once checked to see if run
-        echo -e "This is to see if the generate worksheets is actually being entered" > /data/output/results/"$seqId"/"$panel"/"$seqId"_test.txt
         # identify name of NTC
         ntc=$(for s in /data/output/results/"$seqId"/"$panel"/*/; do echo $(basename $s);done | grep 'NTC')
 

--- a/1_SomaticAmplicon.sh
+++ b/1_SomaticAmplicon.sh
@@ -524,6 +524,9 @@ fi
 if [ $custom_variants == true ]; then
     mkdir hotspot_variants
 
+    # Making marker file for 101X and Myeloid
+    # touch move_complete.txt
+
     for bedFile in $(ls /data/diagnostics/pipelines/SomaticAmplicon/SomaticAmplicon-"$version"/"$panel"/hotspot_variants/*.bed); do
 
         # extract target name
@@ -552,14 +555,22 @@ if [ $custom_variants == true ]; then
         mv "$sampleId"_VariantReport.txt hotspot_variants/"$seqId"_"$sampleId"_"$target"_VariantReport.txt
 
     done
+
+# Making a marker file for 102X
+# else
+    # touch move_complete.txt
+
 fi
 
 ### Run level steps ###
 ## This block should only be carried out when all samples for the panel have been processed
 
+# Creating a marker file to then decide whether block below should be executed or not
+touch move_complete.txt
+
 # number of samples to be processed (i.e. count variables files)/ number of samples that have completed
 expected=$(for i in /data/output/results/"$seqId"/"$panel"/*/*.variables; do echo $i; done | wc -l)
-complete=$(for i in /data/output/results/"$seqId"/"$panel"/*/*VariantReport.txt; do echo $i; done | wc -l)
+complete=$(for i in /data/output/results/"$seqId"/"$panel"/*/move_complete.txt; do echo $i; done | wc -l)
 
 if [ $complete -eq $expected ]; then
 


### PR DESCRIPTION
## Change description

Made changes to create move_complete.txt as there was a bug where the pipeline would skip onto the next step before it was meant to.

## Related issues

closes #35 

## Justification for minor update

This small change does not affect the pipelines sensitivity

## Testing description

**Bioinformatics**

- Verify that new panel/ analysis sheets are applied correctly
- Verify that changes don't affect the triggering of the run level scripts

## Test data location

wren: `/data/output/results/210730_M00766_0410_000000000-JM7NV/`

## Bioinformatics checks

Manually checked that the worksheets generated by virtualhood were created for CRM (101X) and that the combinedQC.txt file was created for BRCA (102X).
The outputs can be seen in `/data/output/results/210730_M00766_0410_000000000-JM7NV/`