### PR TITLE
verification 2.0.3

### DIFF
--- a/1_SomaticAmplicon.sh
+++ b/1_SomaticAmplicon.sh
@@ -641,7 +641,7 @@ if [ $complete -eq $expected ]; then
             # do not generate report where NTC is the query sample
             if [ $sample != $ntc ]; then
 
-                if [ $referral == 'Melanoma' ] || [ $referral == 'Lung' ] || [ $referral == 'Colorectal' ] || [ $referral == 'Glioma' ] || [ $referral == 'Tumour' ] || [ $referral == 'GIST' ] || [ $referral == 'Thyroid' ]; then
+                if [ $referral == 'melanoma' ] || [ $referral == 'lung' ] || [ $referral == 'colorectal' ] || [ $referral == 'glioma' ] || [ $referral == 'tumour' ] || [ $referral == 'gist' ] || [ $referral == 'thyroid' ]; then
                     $VHOOD /opt/conda/bin/VirtualHood-1.2.0/CRM_report_new_referrals.py --runid $seqId --sampleid $sample --worksheet $worklistId --referral $referral --NTC_name $ntc --path /data/output/results/"$seqId"/"$panel"/ --artefacts /data/temp/artefacts_lists/
                 fi
             fi


### PR DESCRIPTION
## Change description
- changed condition of vhood script run to lower case referral types to allow use of new samplesheet generator database.

## Justification for minor update
Doesn’t affect sensitivity – changes are to deal with formatting of samplesheet input.

## Testing description
1. Successfully run through pipeline end to end using lower case samplesheet both myeloid and crm/brca - formatting wont affect any data processing but an error could cause the pipeline to stop running or not generate vhood outputs.
2. MD5SUM/investigation of vhood output (crm/brca) and bam files (myeloid) - shows that no relevant changes are detected in main output data

## Test data location
All test data for this verification is saved on `Wren: /Output/validations/TSO500/ssgen`
investigation results are saved: `L:\Bioinformatics\Validations\samplesheet_generator`

There are two test runs:

- 22-118
- 22-1_21-5843


## Verification results
1. Successfully ran through pipelines end to end, data is saved in `/Output/validations/SomaticAmplicon/`
2. MD5sum and investigations show no changes to relevant files. No result changes found.


Output data is here:

Original run results with uppercase referral in samplesheet - 
`wren results'
New run results - 
`wren results: \validations\SomaticAmplicon\'

