### PR TITLE
Remove tile sequence quality from QC metrics

### DIFF
--- a/1_SomaticAmplicon.sh
+++ b/1_SomaticAmplicon.sh
@@ -54,7 +54,7 @@ countQCFlagFails() {
     # grep -v is an invert match, and selects non-matching lines
     # this is basically scanning the summary.txt file from fastqc output and pulling out specfic columns and then omitting those that have PASS or WARN and leaving only FAIL if any
     # it then counts how many lines have failed
-    grep -E "Basic Statistics|Per base sequence quality|Per tile sequence quality|Per sequence quality scores|Per base N content" "$1" | \
+    grep -E "Basic Statistics|Per base sequence quality|Per sequence quality scores|Per base N content" "$1" | \
     grep -v ^PASS | \
     grep -v ^WARN | \
     wc -l | \


### PR DESCRIPTION
**Resolved #48**

Removed the inclusion of tile sequence quality from sample pass or fail QC. 
Made the same change to the equivalent function in TSO500 post processing. Tested the function in the context of TSO500 post processing, but not formally tested in the somatic amplicon context if that's OK.

Thanks, Patrick