### PR TITLE
Autoqc bugfix

### DIFF
--- a/1_SomaticAmplicon.sh
+++ b/1_SomaticAmplicon.sh
@@ -545,8 +545,11 @@ if [ $custom_coverage == true ]; then
 
         # make blank files for NTC - required for AutoQC upload
         if [[ "$gapsFile" == *"NTC"* ]]; then
-            touch "$sampleId"_null_cosmic.csv
+            if [[ "$panel" == NGHS-101X ]]; then
+                touch "$sampleId"_null_cosmic.csv
             touch "$sampleId"_null_intersect.txt
+            break
+            fi
         fi
 
         echo Running COSMIC for $gapsFile

--- a/1_SomaticAmplicon.sh
+++ b/1_SomaticAmplicon.sh
@@ -547,7 +547,7 @@ if [ $custom_coverage == true ]; then
         if [[ "$gapsFile" == *"NTC"* ]]; then
             if [[ "$panel" == NGHS-101X ]]; then
                 touch "$sampleId"_null_cosmic.csv
-            touch "$sampleId"_null_intersect.txt
+                touch "$sampleId"_null_intersect.txt
             break
             fi
         fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 It covers all changes made from v2.0.4 onwards
 
-## [Unreleased]
+## [v2.1.2] - 2024-10-14
+
+### Fixed
+- Only make blank files for CRM
+
+## [v2.1.1] - 2024-10-07
 
 ### Fixed
 - Made blank *_cosmic.csv and *_intersect.txt required as AutoQC markers


### PR DESCRIPTION
The updated problem was that BRCA was making the cosmic files twice as the referral is renamed from null, which was making autoqc sad. Updated logic to only make blank files for CRM. Tested on 240220_M02641_0579_000000000-LCWJC there's the right number of files.